### PR TITLE
Parameterize message cleanup query and add unit tests

### DIFF
--- a/src/services/dbService.js
+++ b/src/services/dbService.js
@@ -271,7 +271,7 @@ async function deleteOldMessages(daysOld = 90) {
   const client = await pool.connect();
   try {
     const result = await client.query(
-      'DELETE FROM messages WHERE timestamp < NOW() - INTERVAL $1 day',
+      "DELETE FROM messages WHERE timestamp < NOW() - ($1 || ' days')::interval",
       [daysOld]
     );
     

--- a/test/dbService.test.js
+++ b/test/dbService.test.js
@@ -1,0 +1,33 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Import the pool so we can mock it
+const { pool } = require('../src/config/database');
+// Import the function under test
+const { deleteOldMessages } = require('../src/services/dbService');
+
+test('deleteOldMessages removes messages older than the specified days', async () => {
+  const originalConnect = pool.connect;
+  let capturedQuery;
+
+  // Mock the connect method
+  pool.connect = async () => ({
+    query: async (text, params) => {
+      capturedQuery = { text, params };
+      return { rowCount: 3 };
+    },
+    release: () => {}
+  });
+
+  const deletedCount = await deleteOldMessages(7);
+
+  assert.equal(deletedCount, 3);
+  assert.equal(
+    capturedQuery.text,
+    "DELETE FROM messages WHERE timestamp < NOW() - ($1 || ' days')::interval"
+  );
+  assert.deepEqual(capturedQuery.params, [7]);
+
+  // Restore original connect
+  pool.connect = originalConnect;
+});


### PR DESCRIPTION
## Summary
- Refactor `deleteOldMessages` to use a parameterized interval for days
- Add unit test verifying the cleanup query and parameter usage

## Testing
- `node --test test/dbService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6896b27ef44c8332a3d16734c58b9d0c